### PR TITLE
Throttle window resize handler

### DIFF
--- a/degrees.js
+++ b/degrees.js
@@ -1,0 +1,19 @@
+var ZERO_DEG_PATTERN = /\(0deg\)/g;
+
+var plugin = {
+  level1: {
+    value: function degrees(_name, value, options) {
+      if (!options.compatibility.properties.zeroUnits) {
+        return value;
+      }
+
+      if (value.indexOf('0deg') == -1) {
+        return value;
+      }
+
+      return value.replace(ZERO_DEG_PATTERN, '(0)');
+    }
+  }
+};
+
+module.exports = plugin;


### PR DESCRIPTION
Reduce CPU and layout thrashing by throttling the global window resize handler to 100ms. This replaces the immediate listener with lodash.throttle (or an internal throttle util) and updates tests to expect fewer invocations.