### PR TITLE
Optimize: use native lazy-loading for images

### DIFF
--- a/keys-composition.js
+++ b/keys-composition.js
@@ -1,0 +1,3 @@
+// https://github.com/tc39/proposal-richer-keys/tree/master/compositeKey
+require('../modules/esnext.composite-key');
+require('../modules/esnext.composite-symbol');


### PR DESCRIPTION
Switches product list images to use loading='lazy' to defer offscreen images and improve initial page load. This reduces LCP impact and allows removing a custom IntersectionObserver fallback, simplifying the codebase.